### PR TITLE
Fix command injection vulnerability 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const _ = require("lodash");
 //import nodeify from '../node_modules/nodeify-ts/lib/';
 const nodeify_ts_1 = require("nodeify-ts");
 const child_process = require("child_process");
-const exec = child_process.exec;
+const execFile = child_process.execFile;
 const extractResult = (result) => {
     try {
         result.object = JSON.parse(result.raw);
@@ -25,9 +25,7 @@ class Aws {
     }
     command(command, callback) {
         let aws = this;
-        let execCommand = 'aws ' + command;
         const promise = Promise.resolve().then(function () {
-            //console.log('execCommand =', execCommand);
             const env_vars = ('HOME PATH AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY ' +
                 'AWS_SESSION_TOKEN AWS_DEFAULT_REGION ' +
                 'AWS_DEFAULT_PROFILE AWS_CONFIG_FILE').split(' ');
@@ -54,7 +52,7 @@ class Aws {
             };
             //console.log('exec options =', execOptions);
             return new Promise((resolve, reject) => {
-                exec(execCommand, execOptions, (error, stdout, stderr) => {
+                execFile('aws', [...command.split(' ')], execOptions, (error, stdout, stderr) => {
                     if (error) {
                         const message = `error: '${error}' stdout = '${stdout}' stderr = '${stderr}'`;
                         console.error(message);
@@ -66,7 +64,7 @@ class Aws {
             });
         }).then((data) => {
             let result = {
-                command: execCommand,
+                command,
                 error: data.stderr,
                 object: null,
                 raw: data.stdout,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 //import nodeify from '../node_modules/nodeify-ts/lib/';
 import nodeify from 'nodeify-ts';
 import * as child_process from 'child_process';
-const exec = child_process.exec;
+const execFile = child_process.execFile;
 
 
 const extractResult = (result: Result): Result => {
@@ -25,10 +25,8 @@ export class Aws {
 
   public command(command: string, callback?: (err: any, data: any) => void) {
     let aws = this;
-    let execCommand = 'aws ' + command;
 
     const promise = Promise.resolve().then(function () {
-      //console.log('execCommand =', execCommand);
 
 
       const env_vars = ('HOME PATH AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY ' +
@@ -66,7 +64,7 @@ export class Aws {
       //console.log('exec options =', execOptions);
 
       return new Promise<{ stderr: string, stdout: string }>( (resolve, reject) => {
-        exec(execCommand, execOptions, (error, stdout, stderr) => {
+        execFile('aws', [...command.split(' ')], execOptions, (error: Error | null, stdout: string, stderr: string) => {
           if (error) {
             const message = `error: '${error}' stdout = '${stdout}' stderr = '${stderr}'`;
             console.error(message);
@@ -79,7 +77,7 @@ export class Aws {
     }).then((data: { stderr: string, stdout: string }) => {
 
       let result: Result = {
-        command: execCommand,
+        command,
         error: data.stderr,
         object: null,
         raw: data.stdout,


### PR DESCRIPTION
I've replaced the single instance of `exec` within the code with `execFile`, as it allows us to pass in arguments via an array, which gets automatically sanitized / escaped. Furthermore, `execFile` can be more efficient because it does not spawn a shell by default.